### PR TITLE
Changed labeling to use underlying value instead of reflect.Value.

### DIFF
--- a/valuegraph.go
+++ b/valuegraph.go
@@ -123,7 +123,7 @@ func (g *Graph) addValue(parent string, varName string, v reflect.Value, depth i
 			reflect.UnsafePointer,
 			reflect.Chan,
 			reflect.Func:
-			label += `: ` + fmt.Sprint(v)
+			label += `: ` + fmt.Sprint(v.Interface())
 		case reflect.Interface:
 			label += `\ninterface`
 			nodeParams["style"] = "dashed"


### PR DESCRIPTION
The problem I'm trying to solve is if I have a type like 

```
type ID int

func (i ID) String() string {
    return "<custom logic>"
}
```

Then it shows up in the graph as <ID Value>. I'd like my custom String method to be called instead. This change passes the underlying value to fmt.Sprint instead of the wrapped reflect.Value.
